### PR TITLE
Fix usage word

### DIFF
--- a/git-gone
+++ b/git-gone
@@ -2,7 +2,7 @@
 
 usage() {
   cat <<EOF
-usage: git gone [-pldD] [<branch>=origin]
+usage: git gone [-pndD] [<branch>=origin]
 OPTIONS
 	-p	prune remote branch
 	-n	dry run: list the gone branches


### PR DESCRIPTION
There are a typing error in useage of options.
This commit is a correction of typing error.

I referred here:
http://eed3si9n.com/git-gone-cleaning-stale-local-branches