### PR TITLE
fix error command on Mac OS

### DIFF
--- a/git-gone
+++ b/git-gone
@@ -82,9 +82,9 @@ export LC_MESSAGES=C
 gone="$BRANCH/.*: gone]"
 if [ $delete -eq 1 ]; then
   if [ $force -eq 1 ]; then
-    git branch -vv | grep "$gone" | awk '{print $1}' | xargs --no-run-if-empty git branch -D
+    git branch -vv | grep "$gone" | awk '{print $1}' | xargs git branch -D
   else
-    git branch -vv | grep "$gone" | awk '{print $1}' | xargs --no-run-if-empty git branch -d
+    git branch -vv | grep "$gone" | awk '{print $1}' | xargs git branch -d
   fi
 elif [ $list -eq 1 ]; then
   git branch -vv | grep "$gone"


### PR DESCRIPTION
When I command `git gone -D` on Mac OS, There are error message as blow

```
xargs: illegal option -- -
usage: xargs [-0opt] [-E eofstr] [-I replstr [-R replacements]] [-J replstr]
             [-L number] [-n number [-x]] [-P maxprocs] [-s size]
             [utility [argument ...]]
```

so, I removed `xargs` option and then it worked!
I reffered as blow link:
https://stackoverflow.com/questions/8296710/how-to-ignore-xargs-commands-if-stdin-input-is-empty?rq=1